### PR TITLE
Fix package ID

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -88,7 +88,7 @@ android {
     buildToolsVersion "23.0.1"
 
     defaultConfig {
-        applicationId "io.boostnote"
+        applicationId "com.boostnotemobile"
         minSdkVersion 16
         targetSdkVersion 22
         versionCode 6


### PR DESCRIPTION
I mean, I don't really know if I'm an odd one out here or something to be honest.

You changed your Android package id to be `io.boostmobile` which is fine and all, but your actual package ID is still `com.boostmobile` in your Manifest, so you get this when you try to run Android:

![image](https://user-images.githubusercontent.com/1301285/30890859-7e6867b4-a2fd-11e7-943b-44d35b56584a.png)

Probably worth looking into? Idk, no way I'm the only one who ran into this. 