### PR TITLE
Syntax highlight support for markdown preview #21

### DIFF
--- a/app/components/NotePreview.js
+++ b/app/components/NotePreview.js
@@ -245,7 +245,7 @@ export const textToMarkdownAndCodeArray = (baseText) => {
 
 class MarkdownPreview extends Component {
 
-    codeComponent = (args) => {
+    codeComponent(args) {
         if (typeof args['text'] !== 'string') { return }
 
         const baseText = args['text']
@@ -262,7 +262,7 @@ class MarkdownPreview extends Component {
                     fontFamily={this.props.syntaxFontFamily}>{code}</SyntaxHighlighter>)
     }
 
-    markdownComponent = (args) => {
+    markdownComponent(args) {
         if (typeof args['text'] !== 'string') { return }
 
         const baseText       = args['text']
@@ -274,7 +274,7 @@ class MarkdownPreview extends Component {
                     markdownStyles={markdownStyle}>{baseText}</Markdown>)
     }
 
-    textToItem = (args) => {
+    textToItem(args) {
         if (typeof args['text'] != 'string' || args['text'] == '') { return }
 
         const baseText = args['text']
@@ -290,7 +290,7 @@ class MarkdownPreview extends Component {
         }
     }
 
-    notePreviewAsFlatListData = (args) => {
+    notePreviewAsFlatListData(args) {
         // Add markdown comment block at beginning of FlatList's data array,
         // so that it renders faster if original note starts with code block.
         const text = '[//]: #\n' + args['fullText'] + '\n[//]: #'

--- a/app/components/NotePreview.js
+++ b/app/components/NotePreview.js
@@ -166,28 +166,20 @@ const theme = {
     'zenburn': zenburn
 }
 
-const defaultTheme = dracula
+const defaultTheme = theme['dracula']
 
 const styles = StyleSheet.create({
     flex: 1
 })
 
-const baseContainerStyle = {
+const itemContainerStyle = {
     flex: 1,
     paddingLeft:10,
     paddingTop:4,
     paddingBottom: 4,
     paddingRight:10,
-    backgroundColor: '#F5FCFF'
+    backgroundColor: '#f0f0f0'
 }
-
-const codeContainerStyle = Object.assign(baseContainerStyle, {
-    backgroundColor: '#f0f0f0'
-})
-
-const markdownContainerStyle = Object.assign(baseContainerStyle, {
-    backgroundColor: '#f0f0f0'
-})
 
 const markdownStyle = {
     container: {
@@ -274,11 +266,11 @@ class MarkdownPreview extends Component {
         const baseText = args['text']
 
         if(/^(```)+(\w|)+\n/i.test(baseText)) {
-            return (<View style={codeContainerStyle}>
+            return (<View style={itemContainerStyle}>
                         {this.codeComponent({text: baseText, theme: theme[this.props.theme]})}
                     </View>)
         } else {
-            return (<View style={markdownContainerStyle}>
+            return (<View style={itemContainerStyle}>
                         {this.markdownComponent({text: baseText, style: markdownStyle, containerStyle: {}})}
                     </View>)
         }

--- a/app/components/NotePreview.js
+++ b/app/components/NotePreview.js
@@ -1,0 +1,325 @@
+import React, { Component } from 'react'
+import {
+    View,
+    Text,
+    StyleSheet,
+    FlatList
+} from 'react-native';
+import createMarkdownRenderer from 'rn-markdown'
+const Markdown = createMarkdownRenderer({ gfm: true, tables: true })
+import SyntaxHighlighter from 'react-native-syntax-highlighter';
+// Syntax highlight supported languages are listed here.
+// https://github.com/conorhastings/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES.MD
+// Syntax highlight supported themes are listed here.
+// https://github.com/conorhastings/react-native-syntax-highlighter#styles-available
+import {
+    agate,
+    androidstudio,
+    arduinoLight,
+    arta,
+    ascetic,
+    atelierCaveDark,
+    atelierCaveLight,
+    atelierDuneDark,
+    atelierDuneLight,
+    atelierEstuaryDark,
+    atelierEstuaryLight,
+    atelierForestDark,
+    atelierForestLight,
+    atelierHeathDark,
+    atelierHeathLight,
+    atelierLakesideDark,
+    atelierLakesideLight,
+    atelierPlateauDark,
+    atelierPlateauLight,
+    atelierSavannaDark,
+    atelierSavannaLight,
+    atelierSeasideDark,
+    atelierSeasideLight,
+    atelierSulphurpoolDark,
+    atelierSurphulpoolLight,
+    atomOneDark,
+    atomOneLight,
+    brownPaper,
+    codepenEmbed,
+    colorBrewer,
+    dark,
+    darkula,
+    defaultStyle,
+    docco,
+    dracula,
+    far,
+    foundation,
+    githubGist,
+    github,
+    googlecode,
+    grayscale,
+    gruvboxDark,
+    gruvboxLight,
+    hopscotch,
+    hybrid,
+    idea,
+    irBlack,
+    kimbieDark,
+    kimbieLight,
+    magula,
+    monoBlue,
+    monokaiSublime,
+    monokai,
+    obsidian,
+    ocean,
+    paraisoDark,
+    paraisoLight,
+    pojoaque,
+    purebasic,
+    qtcreatorDark,
+    qtcreatorLight,
+    railscasts,
+    rainbow,
+    schoolBook,
+    solarizedDark,
+    solarizedLight,
+    sunburst,
+    tomorrowNightBlue,
+    tomorrowNightBright,
+    tomorrowNightEighties,
+    tomorrowNight,
+    tomorrow,
+    vs,
+    xcode,
+    xt256,
+    zenburn
+} from 'react-syntax-highlighter/dist/styles';
+
+const theme = {
+    'agate': agate,
+    'androidstudio': androidstudio,
+    'arduinoLight': arduinoLight,
+    'arta': arta,
+    'ascetic': ascetic,
+    'atelierCaveDark': atelierCaveDark,
+    'atelierCaveLight': atelierCaveLight,
+    'atelierDuneDark': atelierDuneDark,
+    'atelierDuneLight': atelierDuneLight,
+    'atelierEstuaryDark': atelierEstuaryDark,
+    'atelierEstuaryLight': atelierEstuaryLight,
+    'atelierForestDark': atelierForestDark,
+    'atelierForestLight': atelierForestLight,
+    'atelierHeathDark': atelierHeathDark,
+    'atelierHeathLight': atelierHeathLight,
+    'atelierLakesideDark': atelierLakesideDark,
+    'atelierLakesideLight': atelierLakesideLight,
+    'atelierPlateauDark': atelierPlateauDark,
+    'atelierPlateauLight': atelierPlateauLight,
+    'atelierSavannaDark': atelierSavannaDark,
+    'atelierSavannaLight': atelierSavannaLight,
+    'atelierSeasideDark': atelierSeasideDark,
+    'atelierSeasideLight': atelierSeasideLight,
+    'atelierSulphurpoolDark': atelierSulphurpoolDark,
+    'atelierSurphulpoolLight': atelierSurphulpoolLight,
+    'atomOneDark': atomOneDark,
+    'atomOneLight': atomOneLight,
+    'brownPaper': brownPaper,
+    'codepenEmbed': codepenEmbed,
+    'colorBrewer': colorBrewer,
+    'dark': dark,
+    'darkula': darkula,
+    'defaultStyle': defaultStyle,
+    'docco': docco,
+    'dracula': dracula,
+    'far': far,
+    'foundation': foundation,
+    'githubGist': githubGist,
+    'github': github,
+    'googlecode': googlecode,
+    'grayscale': grayscale,
+    'gruvboxDark': gruvboxDark,
+    'gruvboxLight': gruvboxLight,
+    'hopscotch': hopscotch,
+    'hybrid': hybrid,
+    'idea': idea,
+    'irBlack': irBlack,
+    'kimbieDark': kimbieDark,
+    'kimbieLight': kimbieLight,
+    'magula': magula,
+    'monoBlue': monoBlue,
+    'monokaiSublime': monokaiSublime,
+    'monokai': monokai,
+    'obsidian': obsidian,
+    'ocean': ocean,
+    'paraisoDark': paraisoDark,
+    'paraisoLight': paraisoLight,
+    'pojoaque': pojoaque,
+    'purebasic': purebasic,
+    'qtcreatorDark': qtcreatorDark,
+    'qtcreatorLight': qtcreatorLight,
+    'railscasts': railscasts,
+    'rainbow': rainbow,
+    'schoolBook': schoolBook,
+    'solarizedDark': solarizedDark,
+    'solarizedLight': solarizedLight,
+    'sunburst': sunburst,
+    'tomorrowNightBlue': tomorrowNightBlue,
+    'tomorrowNightBright': tomorrowNightBright,
+    'tomorrowNightEighties': tomorrowNightEighties,
+    'tomorrowNight': tomorrowNight,
+    'tomorrow': tomorrow,
+    'vs': vs,
+    'xcode': xcode,
+    'xt256': xt256,
+    'zenburn': zenburn
+}
+
+const defaultTheme = dracula;
+
+const styles = StyleSheet.create({
+    flex: 1
+});
+
+const baseContainerStyle = {
+    flex: 1,
+    paddingLeft:10,
+    paddingTop:4,
+    paddingBottom: 4,
+    paddingRight:10,
+    backgroundColor: '#F5FCFF'
+}
+
+const codeContainerStyle = Object.assign(baseContainerStyle, {
+    backgroundColor: '#f0f0f0'
+});
+
+const markdownContainerStyle = Object.assign(baseContainerStyle, {
+    backgroundColor: '#f0f0f0'
+});
+
+const markdownStyle = {
+    container: {
+        paddingLeft: 0
+    },
+    heading1: {
+        fontSize: 24,
+        fontWeight: '600',
+        color: '#222222',
+    },
+    link: {
+        color: 'red',
+    },
+    mail_to: {
+        color: 'orange',
+    },
+    text: {
+        color: '#555555',
+    },
+    code: {
+        backgroundColor: '#f0f0f0',
+        marginTop: 5,
+        marginBottom: 5
+    },
+    blockquote: {
+        backgroundColor: '#f8f8f8',
+        padding: 5
+    }
+}
+
+// TODO: needs better regex
+// test code at ../__tests__/NotePreview_module_test.js
+export const textToMarkdownAndCodeArray = (baseText) => {
+    const codePattern = /(```)+(\S|\s)+?(```)/i;
+    if (codePattern.test(baseText)) {
+        const mdBlock   = baseText.split(codePattern)[0];
+        const codeBlock = baseText.match(codePattern)[0];
+        const newText   = baseText.replace(mdBlock,'').replace(codeBlock,'');
+        const nextArray = [];
+        if (mdBlock != "")   { nextArray.push(mdBlock); }
+        if (codeBlock != "") { nextArray.push(codeBlock); }
+        if (newText != "")   { nextArray.push(textToMarkdownAndCodeArray(newText)); }
+        return [].concat.apply([],nextArray);
+    } else {
+        return [].concat.apply([],[baseText]);
+    }
+}
+
+class MarkdownPreview extends Component {
+
+    _codeComponent = (args) => {
+        if (typeof args['text'] !== 'string') { return }
+        const baseText = args['text'];
+        const theme    = args['theme'] || defaultTheme;
+        const codePrefix    = /^(```)+(\w|)+\n/i.exec(baseText)[0];
+        const code          = baseText.replace(codePrefix,'').replace(/\n+(```)$/i,'');
+        const lang          = codePrefix.replace(/^```/,'');
+        const highLightlang = /^(\s)$/.test(lang) ? 'bash' : lang;
+        return (<SyntaxHighlighter
+                    language={highLightlang}
+                    style={theme}
+                    fontSize={this.props.syntaxFontSize}
+                    fontFamily={this.props.syntaxFontFamily}>{code}</SyntaxHighlighter>);
+    }
+
+    _markdownComponent = (args) => {
+        if (typeof args['text'] !== 'string') { return }
+        const baseText       = args['text'];
+        const markdownStyle  = args['style'] || {};
+        const containerStyle = args['containerStyle'] || {};
+        return (<Markdown
+                    contentContainerStyle={containerStyle}
+                    markdownStyles={markdownStyle}>{baseText}</Markdown>);
+    }
+
+    _textToItem = (args) => {
+        if (typeof args['text'] != 'string' || args['text'] == '') return;
+        const baseText = args['text'];
+        if(/^(```)+(\w|)+\n/i.test(baseText)) {
+            return (<View style={codeContainerStyle}>
+                        {this._codeComponent({text: baseText, theme: theme[this.props.theme]})}
+                    </View>);
+        } else {
+            return (<View style={markdownContainerStyle}>
+                        {this._markdownComponent({text: baseText, style: markdownStyle, containerStyle: {}})}
+                    </View>);
+        }
+    }
+
+    _notePreviewAsFlatListData = (args) =>{
+        // Add markdown comment block at beginning of FlatList's data array,
+        // so that it renders faster if original note starts with code block.
+        const text = "[//]: #\n" + args['fullText'] + "\n[//]: #";
+        const markdownAndCodeArray = textToMarkdownAndCodeArray(text);
+        const markdownAndCodeComponentArray = markdownAndCodeArray.map((baseText, index) => {
+            return {key: index, component: this._textToItem({text: baseText})}
+        });
+        return markdownAndCodeComponentArray;
+    }
+
+    render() {
+        return (<View style={styles}>
+                    <FlatList
+                        data={this._notePreviewAsFlatListData({fullText: this.props.text})}
+                        renderItem={({item}) => { return item.component }}
+                        initialNumToRender={0}
+                        {...this.props} />
+                </View>);
+    }
+}
+
+export default class NotePreview extends Component {
+
+    constructor(props) {
+        super(props)
+        this.state = {
+            text: '',
+            theme: '',
+            syntaxFontSize: 16,
+            syntaxFontFamily: ''
+        }
+    }
+
+    render () {
+      return (<MarkdownPreview
+                  theme={this.props.theme}
+                  syntaxFontSize={this.props.syntaxFontSize}
+                  syntaxFontFamily={this.props.syntaxFontFamily}
+                  text={this.props.text} />);
+    }
+}

--- a/app/components/NotePreview.js
+++ b/app/components/NotePreview.js
@@ -8,10 +8,6 @@ import {
 import createMarkdownRenderer from 'rn-markdown'
 const Markdown = createMarkdownRenderer({ gfm: true, tables: true })
 import SyntaxHighlighter from 'react-native-syntax-highlighter'
-// Syntax highlight supported languages are listed here.
-// https://github.com/conorhastings/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES.MD
-// Syntax highlight supported themes are listed here.
-// https://github.com/conorhastings/react-native-syntax-highlighter#styles-available
 import {
     agate,
     androidstudio,
@@ -222,8 +218,6 @@ const markdownStyle = {
     }
 }
 
-// TODO: needs better regex
-// test code at ../__tests__/NotePreview_module_test.js
 export const textToMarkdownAndCodeArray = (baseText) => {
     const codePattern = /(```)+(\S|\s)+?(```)/i
 

--- a/app/components/NotePreview.js
+++ b/app/components/NotePreview.js
@@ -4,10 +4,10 @@ import {
     Text,
     StyleSheet,
     FlatList
-} from 'react-native';
+} from 'react-native'
 import createMarkdownRenderer from 'rn-markdown'
 const Markdown = createMarkdownRenderer({ gfm: true, tables: true })
-import SyntaxHighlighter from 'react-native-syntax-highlighter';
+import SyntaxHighlighter from 'react-native-syntax-highlighter'
 // Syntax highlight supported languages are listed here.
 // https://github.com/conorhastings/react-syntax-highlighter/blob/master/AVAILABLE_LANGUAGES.MD
 // Syntax highlight supported themes are listed here.
@@ -89,7 +89,7 @@ import {
     xcode,
     xt256,
     zenburn
-} from 'react-syntax-highlighter/dist/styles';
+} from 'react-syntax-highlighter/dist/styles'
 
 const theme = {
     'agate': agate,
@@ -170,11 +170,11 @@ const theme = {
     'zenburn': zenburn
 }
 
-const defaultTheme = dracula;
+const defaultTheme = dracula
 
 const styles = StyleSheet.create({
     flex: 1
-});
+})
 
 const baseContainerStyle = {
     flex: 1,
@@ -187,11 +187,11 @@ const baseContainerStyle = {
 
 const codeContainerStyle = Object.assign(baseContainerStyle, {
     backgroundColor: '#f0f0f0'
-});
+})
 
 const markdownContainerStyle = Object.assign(baseContainerStyle, {
     backgroundColor: '#f0f0f0'
-});
+})
 
 const markdownStyle = {
     container: {
@@ -225,101 +225,101 @@ const markdownStyle = {
 // TODO: needs better regex
 // test code at ../__tests__/NotePreview_module_test.js
 export const textToMarkdownAndCodeArray = (baseText) => {
-    const codePattern = /(```)+(\S|\s)+?(```)/i;
+    const codePattern = /(```)+(\S|\s)+?(```)/i
+
     if (codePattern.test(baseText)) {
-        const mdBlock   = baseText.split(codePattern)[0];
-        const codeBlock = baseText.match(codePattern)[0];
-        const newText   = baseText.replace(mdBlock,'').replace(codeBlock,'');
-        const nextArray = [];
-        if (mdBlock != "")   { nextArray.push(mdBlock); }
-        if (codeBlock != "") { nextArray.push(codeBlock); }
-        if (newText != "")   { nextArray.push(textToMarkdownAndCodeArray(newText)); }
-        return [].concat.apply([],nextArray);
+        const mdBlock   = baseText.split(codePattern)[0]
+        const codeBlock = baseText.match(codePattern)[0]
+        const newText   = baseText.replace(mdBlock,'').replace(codeBlock,'')
+        const nextArray = []
+
+        if (mdBlock != '')   { nextArray.push(mdBlock) }
+        if (codeBlock != '') { nextArray.push(codeBlock) }
+        if (newText != '')   { nextArray.push(textToMarkdownAndCodeArray(newText)) }
+
+        return [].concat.apply([],nextArray)
     } else {
-        return [].concat.apply([],[baseText]);
+        return [].concat.apply([],[baseText])
     }
 }
 
 class MarkdownPreview extends Component {
 
-    _codeComponent = (args) => {
+    codeComponent = (args) => {
         if (typeof args['text'] !== 'string') { return }
-        const baseText = args['text'];
-        const theme    = args['theme'] || defaultTheme;
-        const codePrefix    = /^(```)+(\w|)+\n/i.exec(baseText)[0];
-        const code          = baseText.replace(codePrefix,'').replace(/\n+(```)$/i,'');
-        const lang          = codePrefix.replace(/^```/,'');
-        const highLightlang = /^(\s)$/.test(lang) ? 'bash' : lang;
+
+        const baseText = args['text']
+        const theme    = args['theme'] || defaultTheme
+        const codePrefix    = /^(```)+(\w|)+\n/i.exec(baseText)[0]
+        const code          = baseText.replace(codePrefix,'').replace(/\n+(```)$/i,'')
+        const lang          = codePrefix.replace(/^```/,'')
+        const highLightlang = /^(\s)$/.test(lang) ? 'bash' : lang
+
         return (<SyntaxHighlighter
                     language={highLightlang}
                     style={theme}
                     fontSize={this.props.syntaxFontSize}
-                    fontFamily={this.props.syntaxFontFamily}>{code}</SyntaxHighlighter>);
+                    fontFamily={this.props.syntaxFontFamily}>{code}</SyntaxHighlighter>)
     }
 
-    _markdownComponent = (args) => {
+    markdownComponent = (args) => {
         if (typeof args['text'] !== 'string') { return }
-        const baseText       = args['text'];
-        const markdownStyle  = args['style'] || {};
-        const containerStyle = args['containerStyle'] || {};
+
+        const baseText       = args['text']
+        const markdownStyle  = args['style'] || {}
+        const containerStyle = args['containerStyle'] || {}
+
         return (<Markdown
                     contentContainerStyle={containerStyle}
-                    markdownStyles={markdownStyle}>{baseText}</Markdown>);
+                    markdownStyles={markdownStyle}>{baseText}</Markdown>)
     }
 
-    _textToItem = (args) => {
-        if (typeof args['text'] != 'string' || args['text'] == '') return;
-        const baseText = args['text'];
+    textToItem = (args) => {
+        if (typeof args['text'] != 'string' || args['text'] == '') { return }
+
+        const baseText = args['text']
+
         if(/^(```)+(\w|)+\n/i.test(baseText)) {
             return (<View style={codeContainerStyle}>
-                        {this._codeComponent({text: baseText, theme: theme[this.props.theme]})}
-                    </View>);
+                        {this.codeComponent({text: baseText, theme: theme[this.props.theme]})}
+                    </View>)
         } else {
             return (<View style={markdownContainerStyle}>
-                        {this._markdownComponent({text: baseText, style: markdownStyle, containerStyle: {}})}
-                    </View>);
+                        {this.markdownComponent({text: baseText, style: markdownStyle, containerStyle: {}})}
+                    </View>)
         }
     }
 
-    _notePreviewAsFlatListData = (args) =>{
+    notePreviewAsFlatListData = (args) => {
         // Add markdown comment block at beginning of FlatList's data array,
         // so that it renders faster if original note starts with code block.
-        const text = "[//]: #\n" + args['fullText'] + "\n[//]: #";
-        const markdownAndCodeArray = textToMarkdownAndCodeArray(text);
+        const text = '[//]: #\n' + args['fullText'] + '\n[//]: #'
+        const markdownAndCodeArray = textToMarkdownAndCodeArray(text)
         const markdownAndCodeComponentArray = markdownAndCodeArray.map((baseText, index) => {
-            return {key: index, component: this._textToItem({text: baseText})}
-        });
-        return markdownAndCodeComponentArray;
+            return {key: index, component: this.textToItem({text: baseText})}
+        })
+
+        return markdownAndCodeComponentArray
     }
 
     render() {
         return (<View style={styles}>
                     <FlatList
-                        data={this._notePreviewAsFlatListData({fullText: this.props.text})}
+                        data={this.notePreviewAsFlatListData({fullText: this.props.text})}
                         renderItem={({item}) => { return item.component }}
                         initialNumToRender={0}
                         {...this.props} />
-                </View>);
+                </View>)
     }
 }
 
 export default class NotePreview extends Component {
 
-    constructor(props) {
-        super(props)
-        this.state = {
-            text: '',
-            theme: '',
-            syntaxFontSize: 16,
-            syntaxFontFamily: ''
-        }
-    }
-
     render () {
-      return (<MarkdownPreview
-                  theme={this.props.theme}
-                  syntaxFontSize={this.props.syntaxFontSize}
-                  syntaxFontFamily={this.props.syntaxFontFamily}
-                  text={this.props.text} />);
+        return (<MarkdownPreview
+                    theme={this.props.theme}
+                    syntaxFontSize={this.props.syntaxFontSize}
+                    syntaxFontFamily={this.props.syntaxFontFamily}
+                    text={this.props.text} />)
     }
 }

--- a/app/components/__tests__/NotePreview_module_test.js
+++ b/app/components/__tests__/NotePreview_module_test.js
@@ -1,0 +1,27 @@
+import { textToMarkdownAndCodeArray } from '../NotePreview.js';
+
+test('split single markdown text to markdown and code array', () => {
+    const md = "# foo \n*bar* ~baz~\n";
+    const code = "```\n$ echo 'foo bar baz'\n```"
+
+    const input0 = '';
+    expect(textToMarkdownAndCodeArray(input0).length).toBe(1);
+
+    const input1 = md;
+    expect(textToMarkdownAndCodeArray(input1).length).toBe(1);
+
+    const input2 = code;
+    expect(textToMarkdownAndCodeArray(input2).length).toBe(1);
+
+    const input3 = md+md;
+    expect(textToMarkdownAndCodeArray(input3).length).toBe(1);
+
+    const input4 = md+code;
+    expect(textToMarkdownAndCodeArray(input4).length).toBe(2);
+
+    const input5 = code+code;
+    expect(textToMarkdownAndCodeArray(input5).length).toBe(2);
+
+    const input6 = code+code+md+md+code+md+md+code+code+md;
+    expect(textToMarkdownAndCodeArray(input6).length).toBe(8);
+});

--- a/app/components/__tests__/NotePreview_module_test.js
+++ b/app/components/__tests__/NotePreview_module_test.js
@@ -1,27 +1,27 @@
-import { textToMarkdownAndCodeArray } from '../NotePreview.js';
+import { textToMarkdownAndCodeArray } from '../NotePreview.js'
 
 test('split single markdown text to markdown and code array', () => {
-    const md = "# foo \n*bar* ~baz~\n";
+    const md = "# foo \n*bar* ~baz~\n"
     const code = "```\n$ echo 'foo bar baz'\n```"
 
-    const input0 = '';
-    expect(textToMarkdownAndCodeArray(input0).length).toBe(1);
+    const input0 = ''
+    expect(textToMarkdownAndCodeArray(input0).length).toBe(1)
 
-    const input1 = md;
-    expect(textToMarkdownAndCodeArray(input1).length).toBe(1);
+    const input1 = md
+    expect(textToMarkdownAndCodeArray(input1).length).toBe(1)
 
-    const input2 = code;
-    expect(textToMarkdownAndCodeArray(input2).length).toBe(1);
+    const input2 = code
+    expect(textToMarkdownAndCodeArray(input2).length).toBe(1)
 
-    const input3 = md+md;
-    expect(textToMarkdownAndCodeArray(input3).length).toBe(1);
+    const input3 = md+md
+    expect(textToMarkdownAndCodeArray(input3).length).toBe(1)
 
-    const input4 = md+code;
-    expect(textToMarkdownAndCodeArray(input4).length).toBe(2);
+    const input4 = md+code
+    expect(textToMarkdownAndCodeArray(input4).length).toBe(2)
 
-    const input5 = code+code;
-    expect(textToMarkdownAndCodeArray(input5).length).toBe(2);
+    const input5 = code+code
+    expect(textToMarkdownAndCodeArray(input5).length).toBe(2)
 
-    const input6 = code+code+md+md+code+md+md+code+code+md;
-    expect(textToMarkdownAndCodeArray(input6).length).toBe(8);
-});
+    const input6 = code+code+md+md+code+md+md+code+code+md
+    expect(textToMarkdownAndCodeArray(input6).length).toBe(8)
+})

--- a/app/components/__tests__/NotePreview_module_test.js
+++ b/app/components/__tests__/NotePreview_module_test.js
@@ -4,24 +4,17 @@ test('split single markdown text to markdown and code array', () => {
     const md = "# foo \n*bar* ~baz~\n"
     const code = "```\n$ echo 'foo bar baz'\n```"
 
-    const input0 = ''
-    expect(textToMarkdownAndCodeArray(input0).length).toBe(1)
+    const fixtures = [
+      { param: '', outputArrayLength: 1},
+      { param: md, outputArrayLength: 1},
+      { param: code, outputArrayLength: 1},
+      { param: md+md, outputArrayLength: 1},
+      { param: md+code, outputArrayLength: 2},
+      { param: code+code, outputArrayLength: 2},
+      { param: md+code+md+md+code+md+md+code+code+md, outputArrayLength: 8}
+    ]
 
-    const input1 = md
-    expect(textToMarkdownAndCodeArray(input1).length).toBe(1)
-
-    const input2 = code
-    expect(textToMarkdownAndCodeArray(input2).length).toBe(1)
-
-    const input3 = md+md
-    expect(textToMarkdownAndCodeArray(input3).length).toBe(1)
-
-    const input4 = md+code
-    expect(textToMarkdownAndCodeArray(input4).length).toBe(2)
-
-    const input5 = code+code
-    expect(textToMarkdownAndCodeArray(input5).length).toBe(2)
-
-    const input6 = code+code+md+md+code+md+md+code+code+md
-    expect(textToMarkdownAndCodeArray(input6).length).toBe(8)
+    fixtures.forEach((testCase) => {
+      expect(textToMarkdownAndCodeArray(testCase.param).length).toBe(testCase.outputArrayLength)
+    })
 })

--- a/app/views/NoteModal.js
+++ b/app/views/NoteModal.js
@@ -32,7 +32,7 @@ import createMarkdownRenderer from 'rn-markdown'
 const Markdown = createMarkdownRenderer({ gfm: true, tables: true })
 
 import MultilineTextInput from '../components/MultilineTextInput'
-import NotePreview from '../components/NotePreview';
+import NotePreview from '../components/NotePreview'
 
 const styles = {
    switchButton: {

--- a/app/views/NoteModal.js
+++ b/app/views/NoteModal.js
@@ -32,6 +32,7 @@ import createMarkdownRenderer from 'rn-markdown'
 const Markdown = createMarkdownRenderer({ gfm: true, tables: true })
 
 import MultilineTextInput from '../components/MultilineTextInput'
+import NotePreview from '../components/NotePreview';
 
 const styles = {
    switchButton: {
@@ -265,9 +266,15 @@ export default class NoteModal extends React.Component {
                 </View>
         } else {
             return <View style={{margin: 15}}>
-            <Markdown contentContainerStyle={styles.container} markdownStyles={markdownStyles}>
+            {/* <Markdown contentContainerStyle={styles.container} markdownStyles={markdownStyles}>
                 {this.state.text}
-            </Markdown>
+            </Markdown> */}
+            <NotePreview
+                style={styles.container}
+                theme={"github"}
+                syntaxFontSize={14}
+                syntaxFontFamily={Platform.OS === 'ios' ? 'Menlo-Regular' : 'monospace'}
+                text={this.state.text} />
             </View>
         }
     }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-jest": "20.0.3",
     "babel-preset-react-native": "1.9.2",
     "jest": "20.0.3",
+    "react-native-syntax-highlighter": "^1.2.5",
     "react-test-renderer": "16.0.0-alpha.6"
   },
   "jest": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "react-test-renderer": "16.0.0-alpha.6"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "transformIgnorePatterns": [
+      "node_modules/(?!react-native)/"
+    ]
   }
 }


### PR DESCRIPTION
Hi !
This pull request adds syntax highlight support for markdown preview. - realate to #21
I used [react-native-syntax-highlighter](https://github.com/conorhastings/react-native-syntax-highlighter) for it. 
```js
// in app/views/NoteModal.js
...
import NotePreview from '../components/NotePreview'
...
<NotePreview
    style={styles.container}
    theme={"github"}
    syntaxFontSize={14}
    syntaxFontFamily={Platform.OS === 'ios' ? 'Menlo-Regular' : 'monospace'}
    text={this.state.text} />
```
I tried to find which theme suits boostnote-mobile, but couldn't find.
So I just applied github theme. [theme list is here](https://github.com/conorhastings/react-native-syntax-highlighter#styles-available)

![out2](https://user-images.githubusercontent.com/2164119/31778493-bb42eaca-b52b-11e7-839a-d83c75ab455e.gif)
